### PR TITLE
refactor: soapui-runner configurable testreport artifact name

### DIFF
--- a/.github/workflows/soapui-testrunner.md
+++ b/.github/workflows/soapui-testrunner.md
@@ -162,6 +162,16 @@ Docker:
     #
     # Default: latest
     soapui-version: 'latest'
+
+    # When 'true', the SoapUI reports will be uploaded as a GitHub Artifact
+    #
+    # Default: true
+    upload-reports-artifact: true
+
+    # Name of the GitHub Artifact the SoapUI reports should be uploaded under.
+    #
+    # Default: reports-soapui-testreports
+    reports-artifact-name: 'reports-soapui-testreports'
 ```
 
 ## Scenario's

--- a/.github/workflows/soapui-testrunner.yml
+++ b/.github/workflows/soapui-testrunner.yml
@@ -181,7 +181,7 @@ jobs:
           image-name: ${{inputs.image-name}}
 
       - name: SoapUI TestRunner
-        uses: wearefrank/ci-cd-templates/soapui-testrunner@818c296f71c574dded172c26cba43f46e0732a17 #1.4.1
+        uses: wearefrank/ci-cd-templates/soapui-testrunner@soapui-runner-artifact-name
         timeout-minutes: 15
         with:
           project-dir: ${{inputs.project-dir}}

--- a/.github/workflows/soapui-testrunner.yml
+++ b/.github/workflows/soapui-testrunner.yml
@@ -181,7 +181,7 @@ jobs:
           image-name: ${{inputs.image-name}}
 
       - name: SoapUI TestRunner
-        uses: wearefrank/ci-cd-templates/soapui-testrunner@soapui-runner-artifact-name
+        uses: wearefrank/ci-cd-templates/soapui-testrunner@main
         timeout-minutes: 15
         with:
           project-dir: ${{inputs.project-dir}}

--- a/.github/workflows/soapui-testrunner.yml
+++ b/.github/workflows/soapui-testrunner.yml
@@ -121,6 +121,22 @@ on:
             docker stop ${IMAGE_ID:-${IMAGE_TAG:-<organisation>/<image-name>}}
           ```
         required: false
+      upload-reports-artifact:
+        type: boolean
+        description: >
+          When 'true', the SoapUI reports will be uploaded as a GitHub Artifact
+
+          Default: true
+        required: false
+        default: true
+      reports-artifact-name:
+        type: string
+        description: >
+          Name of the GitHub Artifact the SoapUI reports should be uploaded under.
+
+          Default: reports-soapui-testreports
+        required: false
+        default: 'reports-soapui-testreports'
     secrets:
       token:
         required: true
@@ -174,6 +190,8 @@ jobs:
           properties-file: ${{inputs.properties-file}}
           soapui-cmd-options-args: ${{inputs.soapui-cmd-options-args}}
           soapui-version: ${{inputs.soapui-version}}
+          upload-reports-artifact: ${{inputs.upload-reports-artifact}}
+          reports-artifact-name: ${{inputs.reports-artifact-name}}
       
       - name: Teardown Test Environment
         if: inputs.teardown-script != ''

--- a/soapui-testrunner/README.md
+++ b/soapui-testrunner/README.md
@@ -46,6 +46,16 @@ offset back to the actual project root.
     #
     # Default: latest
     soapui-version: 'latest'
+
+    # When 'true', the SoapUI reports will be uploaded as a GitHub Artifact
+    #
+    # Default: true
+    upload-reports-artifact: true
+
+    # Name of the GitHub Artifact the SoapUI reports should be uploaded under.
+    #
+    # Default: reports-soapui-testreports
+    reports-artifact-name: 'reports-soapui-testreports'
 ```
 
 ## Scenario's

--- a/soapui-testrunner/action.yml
+++ b/soapui-testrunner/action.yml
@@ -46,6 +46,20 @@ inputs:
       Default: latest
     required: true
     default: 'latest'
+  upload-reports-artifact:
+    description: >
+      When 'true', the SoapUI reports will be uploaded as a GitHub Artifact
+
+      Default: true
+    required: true
+    default: true
+  reports-artifact-name:
+    description: >
+      Name of the GitHub Artifact the SoapUI reports should be uploaded under.
+
+      Default: reports-soapui-testreports
+    required: true
+    default: 'reports-soapui-testreports'
 
 runs:
   using: "composite"
@@ -125,8 +139,8 @@ runs:
 
     - name: Upload SoapUI Test Reports as artifact
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #4.4.3
-      if: always()
+      if: ${{inputs.upload-reports-artifact}}
       with:
-        name: reports-soapui-testreports
+        name: ${{inputs.reports-artifact-name}}
         path: ${{inputs.reports-dir}}
         


### PR DESCRIPTION
`uses: wearefrank/ci-cd-templates/soapui-testrunner@main` will be replaced in seperate commit with new commit tag.