### PR TITLE
test report upload condition

### DIFF
--- a/soapui-testrunner/action.yml
+++ b/soapui-testrunner/action.yml
@@ -139,7 +139,7 @@ runs:
 
     - name: Upload SoapUI Test Reports as artifact
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 #4.4.3
-      if: always() && inputs.upload-reports-artifact
+      if: always()
       with:
         name: ${{inputs.reports-artifact-name}}
         path: ${{inputs.reports-dir}}


### PR DESCRIPTION
The test reports are not uploaded in case the tests are failed so the condition is being tested by only having always() in the action of uploading the artifact. 